### PR TITLE
Fixing utils.domNodeDisposal.cleanExternalData export

### DIFF
--- a/src/utils.domNodeDisposal.js
+++ b/src/utils.domNodeDisposal.js
@@ -101,3 +101,4 @@ ko.exportSymbol('removeNode', ko.removeNode);
 ko.exportSymbol('utils.domNodeDisposal', ko.utils.domNodeDisposal);
 ko.exportSymbol('utils.domNodeDisposal.addDisposeCallback', ko.utils.domNodeDisposal.addDisposeCallback);
 ko.exportSymbol('utils.domNodeDisposal.removeDisposeCallback', ko.utils.domNodeDisposal.removeDisposeCallback);
+ko.exportSymbol('utils.domNodeDisposal.cleanExternalData', utils.domNodeDisposal.cleanExternalData);


### PR DESCRIPTION
As stated in the documentation (http://knockoutjs.com/documentation/custom-bindings-disposal.html), cleanExternalData is part of ko.utils.domNodeDisposal public API.
The function was not correctly exported, with risks of being mangled during the build step. This patch makes sure the function won't be lost.
